### PR TITLE
Accept url as parameter in creating an sdk instance

### DIFF
--- a/spec/application_sdk_spec.cr
+++ b/spec/application_sdk_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 describe Pterodactyl::ApplicationSdk do
-  host = "137.184.187.126"
+  host = "http://137.184.187.126"
 
   it "succesfully creates a user" do
     WebMockWrapper.application_stub(:post, "create_user_success.json", "/users")

--- a/spec/client_sdk_spec.cr
+++ b/spec/client_sdk_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 describe Pterodactyl::ClientSdk do
-  host = "137.184.187.126"
+  host = "http://137.184.187.126"
   it "retrieve account details" do
     WebMockWrapper.client_stub(:get, "account_details.json", "/account")
 

--- a/src/pterodactyl/application/create_server_request.cr
+++ b/src/pterodactyl/application/create_server_request.cr
@@ -1,5 +1,5 @@
 module Pterodactyl
-    class CreateServerRequest
+  class CreateServerRequest
     property name : String
     property user : Int64
     property egg : Int64

--- a/src/pterodactyl/http_client.cr
+++ b/src/pterodactyl/http_client.cr
@@ -1,9 +1,9 @@
 module Pterodactyl
   class HttpClient
-    property host : String
+    property base_url : String
     property token : String
 
-    def initialize(@host : String, @token : String)
+    def initialize(@base_url : String, @token : String)
       @headers = HTTP::Headers{
         "Content-Type"  => "application/json",
         "Accept"        => "application/json",
@@ -11,43 +11,39 @@ module Pterodactyl
       }
     end
 
-    # Sets the host. Alias of `host=`.
-    def set_host(host : String)
-      @host = host
+    # Sets the base url. Alias of `base_url=`.
+    def set_host(url : String)
+      @base_url = url
     end
 
-    # Returns the base url for which this client will make API requests to.
-    def base_url : URI
-      if host.starts_with?("localhost")
-        URI.parse("http://#{host}")
-      else
-        URI.parse("https://#{host}")
-      end
+    # Returns the URI for which this client will make API requests to.
+    def uri : URI
+      URI.parse(@base_url)
     end
 
     # Performs a GET request on the path.
     def get(path : String)
-      HTTP::Client.new(base_url).get(path, headers: @headers)
+      HTTP::Client.new(uri).get(path, headers: @headers)
     end
 
     # Performs a POST request on the path with a body.
     def post(path : String, body : String = "")
-      HTTP::Client.new(base_url)
+      HTTP::Client.new(uri)
         .post(path, headers: @headers, body: body)
     end
 
     def patch(path : String, body : String = "")
-      HTTP::Client.new(base_url)
+      HTTP::Client.new(uri)
         .patch(path, headers: @headers, body: body)
     end
 
     def put(path : String, body : String = "")
-      HTTP::Client.new(base_url)
+      HTTP::Client.new(uri)
         .put(path, headers: @headers, body: body)
     end
 
     def delete(path : String)
-      HTTP::Client.new(base_url).delete(path, headers: @headers)
+      HTTP::Client.new(uri).delete(path, headers: @headers)
     end
   end
 end


### PR DESCRIPTION
The http client always assumes a `https` scheme when not passed a localhost as `host`. [See failed spec](https://github.com/hostari/valheimserverhosting/actions/runs/4279011269/jobs/7449304772). 

To fix, we give the dev the responsibilty to set the base url.


