### PR TITLE
Allow other body params for create server

### DIFF
--- a/spec/create_server_request_spec.cr
+++ b/spec/create_server_request_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+describe Pterodactyl::CreateServerRequest do
+  it "accepts other named arguments" do
+    req = Pterodactyl::CreateServerRequest.new(
+      name: "test",
+      user: 123,
+      egg: 1,
+      docker_image: "image",
+      startup: "start",
+      environment: {"env" => "val"},
+      limits: {"lim" => 1},
+      feature_limits: {"feat" => 3},
+      allocation: {
+        "default" => 12,
+      },
+      test: "option",
+      property_not_in_docs: "23"
+    )
+
+    req_obj = JSON.parse(req.as_json).as_h
+    req_obj["property_not_in_docs"].should eq("23")
+  end
+end

--- a/src/pterodactyl/application/create_server_request.cr
+++ b/src/pterodactyl/application/create_server_request.cr
@@ -9,6 +9,7 @@ module Pterodactyl
     property limits : Hash(String, Int32)
     property feature_limits : Hash(String, Int32)
     property allocation : Hash(String, Int32)
+    @options : Hash(Symbol, String)
 
     def initialize(
       @name : String,
@@ -19,12 +20,26 @@ module Pterodactyl
       @environment : Hash(String, String),
       @limits : Hash(String, Int32),
       @feature_limits : Hash(String, Int32),
-      @allocation : Hash(String, Int32)
+      @allocation : Hash(String, Int32),
+      **body_params
     )
+      @options = body_params.to_h
     end
 
     def as_json : String
-      {name: name, user: user, egg: egg, docker_image: docker_image, startup: startup, environment: environment, limits: limits, feature_limits: feature_limits, allocation: allocation}.to_json
+      {
+        name:           name,
+        user:           user,
+        egg:            egg,
+        docker_image:   docker_image,
+        startup:        startup,
+        environment:    environment,
+        limits:         limits,
+        feature_limits: feature_limits,
+        allocation:     allocation,
+      }.to_h
+        .merge(@options)
+        .to_json
     end
   end
 end


### PR DESCRIPTION
This allows the user of the shard to send other create_server params. There are params that are useful but not documented properly in docs